### PR TITLE
Add export to CorrelationContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronicled/platform-utils-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Exports basic utility libraries for use in platform components",
   "homepage": "https://github.com/chronicled/platform-utils-javascript#readme",
   "bugs": {

--- a/src/correlation.ts
+++ b/src/correlation.ts
@@ -2,9 +2,9 @@ import { AsyncLocalStorage } from 'async_hooks';
 
 const asyncLocalStorage = new AsyncLocalStorage<CorrelationContext>();
 
-type Returns<T> = () => T;
+export type Returns<T> = () => T;
 
-interface CorrelationContext {
+export interface CorrelationContext {
   correlationId?: string;
   causationId?: string;
   messageId?: string;


### PR DESCRIPTION
There is a change in the old repo where we exported `CorrelationContext`, we need to to the same here as this will be used by the Integration Engine.

I have also bumped the version as I plan to publish the package in order to use it.